### PR TITLE
Add DM-Era support

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,48 @@ $ blocksync-fast -d vol-2024-05-06-00.img --apply-delta -D vol-2024-05-06-00.del
 $ blocksync-fast -d vol-2024-05-06-00.img --apply-delta -D vol-2024-05-07-00.delta
 ```
 
+## DM-Era Support
+
+You can optimize image backups with blocksync-fast when using the device manager "era" feature. With this, you add an extra "era" mapping between a file system and the underlying storage. If you access the "era" mapping instead of the original storage, all write operations are recorded in an extra storage named "era metadata". For details, refer to the Linux kernel document on the topic: https://docs.kernel.org/admin-guide/device-mapper/era.html
+
+You can query which blocks of the "era" mapping where written to since a specified era in the past. If you feed the resulting XML file into blocksync-fast, there will be a substancial operation speed up because only parts of the source device needs to be re-read and checksummed. The "--era file.xml" option is active for "--make-digest" and "--make-delta". Here is an commented example (provided that you have an LVM2 volume group "vg0" with free space as well as root access):
+
+    # Create an empty LV with 1 PE (==4M) size. 4M should be enough for era metadata btree.
+    lvcreate --extents 1 --name era vg0
+    blkdiscard /dev/mapper/vg0-era
+    # Create an LV with 32 PE (==128M) size. This is our image to be backed up.
+    lvcreate --extents 32 --name test vg0
+    # Create device manager mappings
+    dmsetup create test-meta --table "0 8192 linear /dev/mapper/vg0-era 0"
+    dmsetup create test-era --table "0 262144 era /dev/mapper/test-meta /dev/mapper/vg0-test 4096"
+    dmsetup create test-access --table "0 8192 linear /dev/mapper/test-meta 0"
+    # Create a file system (Note: calls blkdiscard ioctl)
+    mkfs.ext4 /dev/mapper/test-era
+    # Take a metadata snapshot, advances era 1 to era 2
+    dmsetup message test-era 0 take_metadata_snap
+    # Query changes during "mkfs"
+    era_invalidate --written-since 1 /dev/mapper/test-access
+    <blocks>
+      <block block="0"/>
+      <range begin="3" end = "5"/>
+      <block block="12"/>
+      <block block="20"/>
+      <range begin="24" end = "27"/>
+      <block block="28"/>
+      <block block="36"/>
+      <block block="63"/>
+    </blocks>
+
+The example above uses era blocks with 4096 sectors (2M) to differentiate from PE size which is 8192 sectors (4M). If you feed the resulting XML into blocksync-fast, the first 2M of /dev/mapper/test-era are checksummed, then 4M skipped, then 4M checksummed, then 14M skipped, and so on...
+
+If you followed the above example, you may want to
+
+    dmsetup remove test-access
+    dmsetup remove test-era
+    dmsetup remove test-meta
+    lvremove vg0/test
+    lvremove vg0/era
+
 ## Limitations and Notes
 
 Blocksync-fast is a tool for fast synchronization of block devices, designed to improve block-based backups. To use it as an automatic backup tool, it is recommended to include it in a BASH script, which will allow you to set up a solution adjusted to your individual needs, using various features and tools available in Linux. It should be taken into account the possibility of synchronization interruption due to network disconnection, device detachment, or other errors that may occur. In case of synchronization failure, the program will return an error code greater than 0, which should be handled in the BASH shell and appropriate actions, such as generating reports or retrying the synchronization, should be taken. It is also important to note that when synchronization with the Digest file is interrupted, there may be an inconsistencies between the state of the Digest file and the target storage device. Therefore, after each such interruption, it is recommended to rebuild the Digest file from the target backup or operate on a copy of the Digest file until full synchronization is achieved.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Blocksync-fast uses the Libgcrypt library and supports many hashing algorithms,
 ## Installation
 
 ```console
- $  CFLAGS="-Wall -Werror -D_FILE_OFFSET_BITS=64 -O3" LIBS="-lm" ./configure
+ $ CFLAGS="-Wall -Werror -D_FILE_OFFSET_BITS=64 -O3" LIBS="-lm" ./configure
  $ make
  $ make install
 ```

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Blocksync-fast uses the Libgcrypt library and supports many hashing algorithms,
 ## Installation
 
 ```console
- $  CFLAGS="-Wall -Werror -D_FILE_OFFSET_BITS=64" LIBS="-lm" ./configure
+ $  CFLAGS="-Wall -Werror -D_FILE_OFFSET_BITS=64 -O3" LIBS="-lm" ./configure
  $ make
  $ make install
 ```

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Blocksync-fast uses the Libgcrypt library and supports many hashing algorithms,
 ## Installation
 
 ```console
- $ ./configure
+ $  CFLAGS="-Wall -Werror -D_FILE_OFFSET_BITS=64" LIBS="-lm" ./configure
  $ make
  $ make install
 ```

--- a/src/blocksync-fast.c
+++ b/src/blocksync-fast.c
@@ -82,7 +82,7 @@ void print_help(void)
 
 					   "-e, --era=PATH\n"
 					   "  Era XML file path. If set, will only process denoted blocks\n"
-					   "  Note: after mkfs or blkdiscard, you need a full digest sync\n"
+					   "  Note: Era XML does not reflect BLKDISCARD changes (trim, mkfs)\n"
 					   "\n"
 
 					   "-E, --era-sectors=N\n"

--- a/src/blocksync-fast.c
+++ b/src/blocksync-fast.c
@@ -32,8 +32,7 @@ void print_help(void)
 
 	fprintf(flag.prst, "\n");
 
-	fprintf(flag.prst, "Usage:\n",
-			process_name);
+	fprintf(flag.prst, "Usage:\n");
 
 	fprintf(flag.prst, " %s [options]\n",
 			process_name);
@@ -747,11 +746,11 @@ void make_digest(void)
 
 void init_params(void)
 {
-	if (flag.oper_mode == MAKEDELTA && delta.path == NULL || flag.oper_mode == MAKEDIGEST && digest.path == NULL)
+	if ((flag.oper_mode == MAKEDELTA && delta.path == NULL) || (flag.oper_mode == MAKEDIGEST && digest.path == NULL))
 		flag.prst = stderr;
 
 	if (flag.silent)
-		freopen("/dev/null", "w", flag.prst) != NULL;
+		freopen("/dev/null", "w", flag.prst);
 
 	init_map_methods();
 
@@ -781,7 +780,7 @@ void init_params(void)
 		if (digest.path != NULL)
 			init_digest_file();
 		else
-			fprintf(flag.prst, "Warning: works without digest file.\n", process_name);
+			fprintf(flag.prst, "Warning: %s works without digest file.\n", process_name);
 
 		if (IS_MODE(digest.open_mode, READ))
 			dst.open_mode ^= READ;
@@ -816,7 +815,7 @@ void init_params(void)
 		}
 
 		if (digest.path == NULL)
-			fprintf(flag.prst, "Warning: works without digest file.\n", process_name);
+			fprintf(flag.prst, "Warning: %s works without digest file.\n", process_name);
 
 		if (param.hash_algo != NULL)
 			check_algo_param();
@@ -887,7 +886,7 @@ void init_params(void)
 		dst.buf_size = (dst.data_size < dst.max_buf_size ? dst.data_size : dst.max_buf_size);
 	}
 
-	bool buf_adj_delta = false;
+	__attribute__((unused))bool buf_adj_delta = false;
 
 	if (flag.oper_mode == MAKEDELTA)
 	{
@@ -924,7 +923,7 @@ void init_params(void)
 		{
 			digest.block_size = param.algo.size;
 			digest.max_buf_size = (src.max_buf_size / src.block_size) * digest.block_size;
-			bool buf_adj_digest = adjust_buffer(&digest.max_buf_size, digest.block_size);
+			__attribute__((unused))bool buf_adj_digest = adjust_buffer(&digest.max_buf_size, digest.block_size);
 
 			if (IS_MODE(digest.open_mode, DIRECT) || IS_MODE(digest.open_mode, PIPE))
 				digest.buf_data = realloc(digest.buf_data, digest.max_buf_size);
@@ -933,7 +932,7 @@ void init_params(void)
 		}
 
 		if (param.block_size < src.stat.st_blksize)
-			fprintf(flag.prst, "Warning: given block size is smaller than the block size of the source device, which is %zu bytes\n",
+			fprintf(flag.prst, "Warning: given block size is smaller than the block size of the source device, which is %lu bytes\n",
 					src.stat.st_blksize);
 	}
 
@@ -954,7 +953,7 @@ void init_params(void)
 				param.algo.symbol, param.algo.size);
 
 		if (param.algo.size > param.block_size)
-			fprintf(flag.prst, "Warning: block size '%ld' is smaller than hash '%s' size\n", param.block_size, param.algo.symbol);
+			fprintf(flag.prst, "Warning: block size '%zu' is smaller than hash '%s' size\n", param.block_size, param.algo.symbol);
 	}
 
 	if (param.data_size > (size_t)(1UL * 1024 * 1024 * 1024 * 1024)) {

--- a/src/blocksync-fast.c
+++ b/src/blocksync-fast.c
@@ -80,6 +80,10 @@ void print_help(void)
 					   "  Delta file path. If none, data write to stdout or read from stdin\n"
 					   "\n"
 
+					   "-e, --era=PATH\n"
+					   "  Era XML file path. If set, will only process denoted blocks\n"
+					   "\n"
+
 					   "-b, --block-size=N[KMG]\n"
 					   "  Block size in N bytes for writing and checksum calculations\n"
 					   "  (default:4K)\n"
@@ -293,6 +297,7 @@ void parse_options(int argc, char **argv)
 		{"size", required_argument,	0, 'S'},
 		{"digest", required_argument, 0, 'f'},
 		{"delta", required_argument, 0, 'D'},
+		{"era", required_argument, 0, 'e'},
 		{"buffer-size", required_argument, 0, 1001},
 		{"block-size", required_argument, 0, 'b'},
 		{"algo", required_argument, 0, 'a'},
@@ -340,6 +345,9 @@ void parse_options(int argc, char **argv)
 			break;
 		case 'a':
 			param.hash_algo = optarg;
+			break;
+		case 'e':
+			param.era = optarg;
 			break;
 		case 1001:
 			param.max_buf_size = parse_units(optarg);

--- a/src/blocksync-fast.c
+++ b/src/blocksync-fast.c
@@ -251,9 +251,9 @@ void print_summary(void)
 	if (flag.progress > 0)
 		fprintf(flag.prst, "\n");
 
-	fprintf(flag.prst, "%s: %zu/%zu blocks, %zu/%zu bytes.\n",
+	fprintf(flag.prst, "%s: %zu/%zu blocks, %zu/%llu bytes.\n",
 			flag.oper_mode == MAKEDIGEST ? (IS_MODE(digest.open_mode, READ) ? "Updated" : "Created") : (IS_MODE(dst.open_mode, READ) ? "Updated" : "Copied"),
-			prog.wri_blocks, param.num_blocks, prog.wri_bytes, param.data_size);
+			prog.wri_blocks, param.num_blocks, prog.wri_bytes, (unsigned long long)param.data_size);
 
 	if ( flag.oper_mode == BLOCKSYNC && IS_MODE(src.open_mode, PIPE_R) ) {
 	
@@ -956,11 +956,11 @@ void init_params(void)
 			fprintf(flag.prst, "Warning: block size '%zu' is smaller than hash '%s' size\n", param.block_size, param.algo.symbol);
 	}
 
-	if (param.data_size > (size_t)(1UL * 1024 * 1024 * 1024 * 1024)) {
+	if (param.data_size > (off_t)(1ULL * 1024 * 1024 * 1024 * 1024)) {
 		param.pro_prec = 2;
 		param.pro_fact = 100;
 	}
-	else if (param.data_size > (size_t)(100UL * 1024 * 1024 * 1024)) {
+	else if (param.data_size > (off_t)(100ULL * 1024 * 1024 * 1024)) {
 		param.pro_prec = 1;
 		param.pro_fact = 10;
 	}

--- a/src/blocksync-fast.c
+++ b/src/blocksync-fast.c
@@ -932,8 +932,8 @@ void init_params(void)
 		}
 
 		if (param.block_size < src.stat.st_blksize)
-			fprintf(flag.prst, "Warning: given block size is smaller than the block size of the source device, which is %lu bytes\n",
-					src.stat.st_blksize);
+			fprintf(flag.prst, "Warning: given block size is smaller than the block size of the source device, which is %llu bytes\n",
+					(unsigned long long)src.stat.st_blksize);
 	}
 
 	if (flag.oper_mode == BLOCKSYNC || flag.oper_mode == APPLYDELTA)

--- a/src/blocksync-fast.c
+++ b/src/blocksync-fast.c
@@ -85,6 +85,10 @@ void print_help(void)
 					   "  Note: after mkfs or blkdiscard, you need a full digest sync\n"
 					   "\n"
 
+					   "-E, --era-sectors=N\n"
+					   "  Era block size in sectors (default: 4096)\n"
+					   "\n"
+
 					   "-b, --block-size=N[KMG]\n"
 					   "  Block size in N bytes for writing and checksum calculations\n"
 					   "  (default:4K)\n"
@@ -299,6 +303,7 @@ void parse_options(int argc, char **argv)
 		{"digest", required_argument, 0, 'f'},
 		{"delta", required_argument, 0, 'D'},
 		{"era", required_argument, 0, 'e'},
+		{"era-sectors", required_argument, 0, 'E'},
 		{"buffer-size", required_argument, 0, 1001},
 		{"block-size", required_argument, 0, 'b'},
 		{"algo", required_argument, 0, 'a'},
@@ -349,6 +354,9 @@ void parse_options(int argc, char **argv)
 			break;
 		case 'e':
 			param.era = optarg;
+			break;
+		case 'E':
+			param.era_sectors = atoi(optarg);
 			break;
 		case 1001:
 			param.max_buf_size = parse_units(optarg);

--- a/src/blocksync-fast.c
+++ b/src/blocksync-fast.c
@@ -937,8 +937,11 @@ void init_params(void)
 	if ((flag.oper_mode == MAKEDELTA && delta.path == NULL) || (flag.oper_mode == MAKEDIGEST && digest.path == NULL))
 		flag.prst = stderr;
 
-	if (flag.silent)
-		freopen("/dev/null", "w", flag.prst);
+	if (flag.silent && (NULL == freopen("/dev/null", "w", flag.prst)))
+	{
+		fprintf(stderr, "No /dev/null!?\n");
+		cleanup(EXIT_FAILURE);
+	}
 
 	init_map_methods();
 

--- a/src/digest_info.c
+++ b/src/digest_info.c
@@ -63,7 +63,7 @@ void digest_info(void)
 		digest.buf_data = malloc(digest.max_buf_size);
 	}
 
-	size_t dds = digest.data_size;
+	off_t dds = digest.data_size;
 	digest.data_size = HEADER_SIZE;
 	map_buffer(&digest);
 
@@ -158,7 +158,7 @@ void delta_info(void)
 		delta.buf_data = malloc(delta.max_buf_size);
 	}
 
-	size_t dds = delta.data_size;
+	off_t dds = delta.data_size;
 	delta.data_size = HEADER_SIZE;
 	map_buffer(&delta);
 

--- a/src/globals.c
+++ b/src/globals.c
@@ -142,7 +142,7 @@ void map_buffer(struct dev *dev)
 
 			if (rbytes < 0)
 			{
-				fprintf(stderr, "%s: error while reading from stdin : %s\n", process_name, dev->path, strerror(errno));
+				fprintf(stderr, "%s: error while reading from stdin : %s\n", process_name, strerror(errno));
 				cleanup(EXIT_FAILURE);
 			}
 

--- a/src/globals.c
+++ b/src/globals.c
@@ -78,7 +78,7 @@ const struct symbol_value_desc algos[] =
 
 		{"", 0, 0, 0, ""}};
 
-struct param param = {NULL, D_BLOCK_SIZE, D_BUFFER_SIZE, 0, NULL, 0, 0, 1, "", false, NULL, algos[D_ALGO]};
+struct param param = {NULL, D_BLOCK_SIZE, D_BUFFER_SIZE, 0, NULL, 0, 0, 1, "", false, NULL, algos[D_ALGO], NULL};
 
 void get_ptr(struct dev *dev)
 {

--- a/src/globals.c
+++ b/src/globals.c
@@ -78,7 +78,7 @@ const struct symbol_value_desc algos[] =
 
 		{"", 0, 0, 0, ""}};
 
-struct param param = {NULL, D_BLOCK_SIZE, D_BUFFER_SIZE, 0, NULL, 0, 0, 1, "", false, NULL, algos[D_ALGO], NULL};
+struct param param = {NULL, D_BLOCK_SIZE, D_BUFFER_SIZE, 0, NULL, 0, 0, 1, "", false, NULL, algos[D_ALGO], NULL, 4096};
 
 void get_ptr(struct dev *dev)
 {

--- a/src/globals.h
+++ b/src/globals.h
@@ -21,7 +21,8 @@
 
 #define PROGRAM_NAME "blocksync-fast"
 #define AUTHORS \
-	"Marcin Koczwara <mk@nethorizon.pl>"
+	"Marcin Koczwara <mk@nethorizon.pl>" \
+	"Sven-Ola Tuecke <sven-ola@gmx.de>"
 
 #define BSF_VERSION "1.07"
 #define COPYRIGHT "Copyright (C) 2024 " AUTHORS

--- a/src/globals.h
+++ b/src/globals.h
@@ -104,7 +104,7 @@ extern struct dev
 	int fd;
 	struct stat stat;
 	off_t abs_off, buf_off, rel_off, mov_off;
-	size_t data_size;
+	off_t data_size;
 	size_t block_size;
 	size_t buf_size;
 	size_t max_buf_size;
@@ -177,7 +177,7 @@ extern struct param
 	size_t max_buf_size;
 	size_t num_blocks;
 	char *h_data_size;
-	size_t data_size;
+	off_t data_size;
 	int pro_prec;
 	int pro_fact;
 	char pro_form[20];

--- a/src/globals.h
+++ b/src/globals.h
@@ -184,6 +184,7 @@ extern struct param
 	bool hash_use;
 	const char *hash_algo;
 	struct symbol_value_desc algo;
+	const char *era;
 } param;
 
 enum oper_modes

--- a/src/globals.h
+++ b/src/globals.h
@@ -185,6 +185,7 @@ extern struct param
 	const char *hash_algo;
 	struct symbol_value_desc algo;
 	const char *era;
+	size_t era_sectors;
 } param;
 
 enum oper_modes

--- a/src/init.c
+++ b/src/init.c
@@ -120,7 +120,7 @@ void init_src_device(void)
                     src.path, format_units(src.data_size, true));
     }
 
-    if (src.data_size < 1)
+    if (src.data_size == (off_t)-1)
     {
         fprintf(stderr, "%s: source device is empty\n", process_name);
         cleanup(EXIT_FAILURE);
@@ -529,7 +529,7 @@ void init_src_delta(void)
         fprintf(flag.prst, "Data to apply-delta is read from STDIN\n");
         delta.fd = STDIN_FILENO;
         delta.open_mode = PIPE;
-        delta.data_size = SIZE_MAX;
+        delta.data_size = LLONG_MAX;
     }
 
     delta.open_mode |= READ;

--- a/src/utils.c
+++ b/src/utils.c
@@ -19,12 +19,12 @@
 #include "globals.h"
 #include <math.h>		// ceil
 
-long parse_units(char *size)
+off_t parse_units(char *size)
 {
-    long number;
+    off_t number;
     char *str;
 
-    number = strtoul(size, &str, 10);
+    number = strtoull(size, &str, 10);
 
     if (strcasecmp(str, "k") == 0 || strcasecmp(str, "kib") == 0)
         number *= 1024;
@@ -42,7 +42,7 @@ long parse_units(char *size)
     return number;
 }
 
-char *format_units(long long int size, bool show_bytes)
+char *format_units(off_t size, bool show_bytes)
 {
     char *number_str = malloc(80);
 
@@ -57,7 +57,7 @@ char *format_units(long long int size, bool show_bytes)
     else
     {
         if (show_bytes)
-            sprintf(number_str, ("%llu bytes"), size);
+            sprintf(number_str, ("%llu bytes"), (unsigned long long)size);
         else
             sprintf(number_str, ("%.0f B"), (double)size);
 
@@ -68,7 +68,7 @@ char *format_units(long long int size, bool show_bytes)
     {
         char *number_str2 = malloc(80);
         memcpy(number_str2, number_str, 80);
-        sprintf(number_str, ("%s, %llu bytes"), number_str2, size);
+        sprintf(number_str, ("%s, %llu bytes"), number_str2, (unsigned long long)size);
     }
 
     return number_str;

--- a/src/utils.h
+++ b/src/utils.h
@@ -19,8 +19,8 @@
 #ifndef UTILS_H
 #define UTILS_H
 
-long parse_units(char *size);
-char *format_units(long long int size, bool show_bytes);
+off_t parse_units(char *size);
+char *format_units(off_t size, bool show_bytes);
 off_t p2r(off_t x);
 
 #endif


### PR DESCRIPTION
Hey... I now have tested the --era switch in vitro as well as on a live system. It may be ready for prime time, so here is the pull RQ. I add my test scripts here, just in case you want to give it a try. If necessary, I can provide SSH access to a live test system (one of those little things depicted with the last pull RQ).

**era-test.sh**
```
#!/bin/sh

case $(id -u) in 0|root);;*)
	echo "This tests need root" >&2
	exit 1
;;esac

if ! vgs vg0>/dev/null;then
	echo "You need an LVS volume group called vg0" >&2
	exit 1
fi

PE=32
PE_SIZE=$(( 4 * 1024 * 1024 ))
ERA_SIZE=$(( 4096 * 512 ))

era=true

case ${1} in c|create)
	lvcreate --yes --extents 1 --name era vg0
	dm=$(readlink -f /dev/mapper/vg0-era)
	era_size=$(cat /sys/class/block/${dm##*/}/size)
	dd if=/dev/zero of=/dev/mapper/vg0-era bs=${PE_SIZE} count=1 status=none

	lvcreate --yes --extents ${PE} --name test vg0
	dm=$(readlink -f /dev/mapper/vg0-test)
	lv_size=$(cat /sys/class/block/${dm##*/}/size)

	if false;then
		dd if=/dev/zero bs=${PE_SIZE} count=${PE} status=none|tr "\000" "\377"|dd of=/dev/mapper/vg0-test bs=${PE_SIZE} status=none
	elif false;then
		dd if=/dev/zero bs=${PE_SIZE} count=${PE} status=none|dd of=/dev/mapper/vg0-test bs=${PE_SIZE} status=none
	elif false;then
		i=0
		while [ ${i} -lt $(( ${PE} * ${PE_SIZE} / ${ERA_SIZE} )) ];do
			printf "magic sot %05d\n" ${i}|dd of=/dev/mapper/vg0-test bs=${ERA_SIZE} seek=${i} count=1 conv=notrunc status=none
			i=$(( ${i} + 1 ))
		done
	elif true;then
		blkdiscard /dev/mapper/vg0-test
	fi

	if ${era};then
		dmsetup create test-meta   --table "0 ${era_size} linear /dev/mapper/vg0-era 0"
		dmsetup create test-era    --table "0 ${lv_size} era /dev/mapper/test-meta /dev/mapper/vg0-test 4096"
		dmsetup create test-access --table "0 ${era_size} linear /dev/mapper/test-meta 0"
	fi
;;d|dump)
	era_dump /dev/mapper/test-access
;;t|take)
	dmsetup message test-era 0 drop_metadata_snap 2>/dev/null
	dmsetup message test-era 0 take_metadata_snap
	set -- $(dmsetup status test-era)
	echo "era now ${6}"
;;poke)
	if [ 0 -le ${2} ] 2>/dev/null && [ ${2} -lt $(( ${PE} * ${PE_SIZE} / ${ERA_SIZE} )) ];then
		printf "% 5d\n" ${2}|dd of=/dev/mapper/test-era bs=${ERA_SIZE} seek=${2} count=1 conv=notrunc status=none
	else
		echo "Number 0..$(( ${PE} * ${PE_SIZE} / ${ERA_SIZE} )) missing." >&2
		exit 1
	fi
;;Poke)
	if [ 0 -le ${2} ] 2>/dev/null && [ ${2} -lt $(( ${PE} * ${PE_SIZE} / ${ERA_SIZE} )) ];then
		printf "% 5d\n" ${2}|dd of=/dev/mapper/vg0-test bs=${ERA_SIZE} seek=${2} count=1 conv=notrunc status=none
	else
		echo "Number 0..$(( ${PE} * ${PE_SIZE} / ${ERA_SIZE} )) missing." >&2
		exit 1
	fi
;;peek)
	if [ 0 -le ${2} ] 2>/dev/null && [ ${2} -lt $(( ${PE} * ${PE_SIZE} / ${ERA_SIZE} )) ];then
		dd if=/dev/mapper/test-era bs=${ERA_SIZE} skip=${2} count=1 conv=notrunc status=none|hexdump -C|head -n1
	else
		echo "Number 0..$(( ${PE} * ${PE_SIZE} / ${ERA_SIZE} )) missing." >&2
		exit 1
	fi
;;Peek)
	if [ 0 -le ${2} ] 2>/dev/null && [ ${2} -lt $(( ${PE} * ${PE_SIZE} / ${ERA_SIZE} )) ];then
		dd if=/dev/mapper/vg0-test bs=${ERA_SIZE} skip=${2} count=1 conv=notrunc status=none|hexdump -C|head -n1
	else
		echo "Number 0..$(( ${PE} * ${PE_SIZE} / ${ERA_SIZE} )) missing." >&2
		exit 1
	fi
;;w|written)
	since=${2}
	set -- $(dmsetup status test-era)
	case ${since} in "")
		since=$(( ${6} - 1 ))
	;;esac
	era_invalidate --written-since ${since} /dev/mapper/test-access
;;m|md5|M|MD5)
	i=0
	old=
	test -f ${0%.*}.md5 && mv ${0%.*}.md5 ${0%.*}.old
	while [ ${i} -lt $(( ${PE} * ${PE_SIZE} / ${ERA_SIZE} )) ];do
		test -f ${0%.*}.old && old=$(sed -n "$(( ${i} + 1 ))p" ${0%.*}.old)
		case ${1} in M|MD5)
			md5=$(dd if=/dev/mapper/vg0-test bs=${ERA_SIZE} skip=${i} count=1 status=none|md5sum|sed 's,^\(......\).*,\1,')
		;;*)
			md5=$(dd if=/dev/mapper/test-era bs=${ERA_SIZE} skip=${i} count=1 status=none|md5sum|sed 's,^\(......\).*,\1,')
		;;esac
		num="$(printf "%2d" ${i})"
		case ${old} in "")
			echo "${num}: ${md5}"
		;;${md5})
			echo "${num}: ${md5}  ${old}"
		;;*)
			echo "${num}: ${md5}!=${old}"
		;;esac
		echo "${md5}" >> ${0%.*}.md5
		i=$(( ${i} + 1 ))
	done
	rm -f ${0%.*}.old
;;s|snap)
	lvcreate --extents $(( ${PE} / 8 )) --snapshot --name test-snap /dev/mapper/vg0-test
;;u|unsnap)
	lvremove --yes vg0/test-snap
;;r|remove)
	if ${era};then
		test -b /dev/mapper/test-access && dmsetup remove test-access
		test -b /dev/mapper/test-era && dmsetup remove test-era
		test -b /dev/mapper/test-meta && dmsetup remove test-meta
	fi

	test -b /dev/mapper/vg0-test && lvremove --yes vg0/test
	test -b /dev/mapper/vg0-era && lvremove --yes vg0/era

	rm -f ${0%.*}.md5
;;i|is)
	dmsetup status test-era
;;esac
```

**digest-test.sh**
```
#!/bin/bash

case $(id -u) in 0|root);;*)
	echo "This tests need root" >&2
	exit 1
;;esac

if ! vgs vg0>/dev/null;then
	echo "You need an LVS volume group called vg0" >&2
	exit 1
fi

${0%/*}/era-test.sh r
${0%/*}/era-test.sh c

${0%/*}/era-test.sh w | tee era.xml
time blocksync-fast --make-digest --src /dev/mapper/test-era --digest test.digest
time blocksync-fast --make-digest --src /dev/mapper/test-era --digest test-era.digest --era era.xml
dd if=test.digest skip=1 status=none|md5sum
dd if=test-era.digest skip=1 status=none|md5sum

mkfs.ext4 -F /dev/mapper/test-era
${0%/*}/era-test.sh t
${0%/*}/era-test.sh w | tee era.xml

time blocksync-fast --make-digest --src /dev/mapper/test-era --digest test.digest
time blocksync-fast --make-digest --src /dev/mapper/test-era --digest test-era.digest --era era.xml

dd if=test.digest skip=1 status=none|md5sum
dd if=test-era.digest skip=1 status=none|md5sum
```

**delta-test.sh**
```
#!/bin/bash

case $(id -u) in 0|root);;*)
	echo "This tests need root" >&2
	exit 1
;;esac

if ! vgs vg0>/dev/null;then
	echo "You need an LVS volume group called vg0" >&2
	exit 1
fi

case ${1} in ad-std)
	dev=$(readlink -f /dev/mapper/test-era)
	size=$(cat /sys/class/block/${dev##*/}/size)
	truncate --size=$(( 512 * ${size} )) test.img
	time blocksync-fast --apply-delta --dst=test.img --delta test.delta
	md5sum /dev/mapper/test-era test.img
;;ad-era)
	dev=$(readlink -f /dev/mapper/test-era)
	size=$(cat /sys/class/block/${dev##*/}/size)
	truncate --size=$(( 512 * ${size} )) test-era.img
	time blocksync-fast --apply-delta --dst=test-era.img --delta test-era.delta
	md5sum /dev/mapper/test-era test-era.img
;;md-std)
	time blocksync-fast --make-delta --src /dev/mapper/test-era --digest test.digest --delta test.delta --force
;;md-era)
	${0%/*}/era-test.sh t
	${0%/*}/era-test.sh w | tee era.xml
	time blocksync-fast --make-delta --src /dev/mapper/test-era --digest test-era.digest --delta test-era.delta --force --era era.xml
;;"")
	${0%/*}/era-test.sh r
	${0%/*}/era-test.sh c

	${0%/*}/era-test.sh w | tee era.xml
	time blocksync-fast --make-digest --src /dev/mapper/test-era --digest test.digest
	time blocksync-fast --make-digest --src /dev/mapper/test-era --digest test-era.digest --era era.xml
	dd if=test.digest skip=1 status=none|md5sum
	dd if=test-era.digest skip=1 status=none|md5sum

	mkfs.ext4 -F /dev/mapper/test-era
	${0%/*}/era-test.sh t
	${0%/*}/era-test.sh w | tee era.xml

	time blocksync-fast --make-delta --src /dev/mapper/test-era --digest test.digest --delta test.delta --force
	time blocksync-fast --make-delta --src /dev/mapper/test-era --digest test-era.digest --delta test-era.delta --force --era era.xml
	dd if=test.digest skip=1 status=none|md5sum
	dd if=test-era.digest skip=1 status=none|md5sum
	dd if=test.delta skip=1 status=none|md5sum
	dd if=test-era.delta skip=1 status=none|md5sum

	rm -f test.img
	rm -f test-era.img
;;*)
	echo "After initial test with '${0}' (no args), you may use" >&2
	echo "'${0} ad-std', then change something in /dev/mapper/test-era" >&2
	echo "then '${0} md-std'. Same with ad-era, chg, ad-std..." >&2
;;esac
```