### PR TITLE
inital debian package

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,0 +1,5 @@
+blocksync-fast (1.0.7-1) unstable; urgency=medium
+
+  * Build latest commit
+
+ -- nethappen <mk@nethappen.pl>  Tue, 03 Jun 2025 23:15:58 +0200

--- a/debian/control
+++ b/debian/control
@@ -1,0 +1,35 @@
+Source: blocksync-fast
+Section: admin
+Priority: extra
+Maintainer: nethappen <mk@nethappen.pl>
+Build-Depends: debhelper (>= 9),
+ debhelper-compat (= 10),
+ autoconf-archive,
+ pkg-config,
+ libgcrypt-dev,
+ libxxhash-dev
+Standards-Version: 3.9.6
+
+Package: blocksync-fast
+Architecture: any
+Depends: ${shlibs:Depends}, ${misc:Depends}
+Description: Blocksync-fast is a program written in C that clones and
+ synchronizes any block devices (entire disks, partitions) or files (disk
+ images) using fast and efficient methods. It uses buffered reads and
+ writes to combine adjacent blocks together reducing the number of I/O
+ operations. At synchronization process program overwrites only changed
+ blocks which reduces data transfer and maintains blocks deduplication in
+ Copy-on-write file systems.
+ .
+ The digest file can be used to store checksums of blocks from a previous
+ sync to avoid read operations from the target disk. This optimization is
+ especially desirable when synchronizing fast NVM drives with slower HDD
+ drives or when transferring data over the network. The program can also
+ creates delta file that stores only differing blocks which can be
+ applied to the destination.
+ .
+ Blocksync-fast uses the Libgcrypt library and supports many hashing
+ algorithms, both cryptographic and non-cryptographic. Optionally, it can
+ also use hashing algorithms from the xxHash family, which offers the
+ very high speed of processed data on processors with SSE2, AVX2
+ instructions

--- a/debian/rules
+++ b/debian/rules
@@ -1,0 +1,4 @@
+#!/usr/bin/make -f
+
+%:
+	dh $@


### PR DESCRIPTION
Provide a minimal debian directory for building a package. Take the following steps to build:

* install build-essential and devscripts
* in the source-tree of blocksync-fast run
  - mk-build-deps
  - sudo apt install ./blocksync-fast-build-deps_*.deb
  - debuild -us -uc -b

The final package is one directory level up.

Using the debian helpers all autotools refreshes are handled and the control-file has a more complete build dependency list for Debian based systems (mainly autoconf-archive and pkg-config are needed to get xxhash working).