### PR TITLE
Add GitHub Actions workflow to build (and upload release artifacts on tag, and upload "assets" on push)

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -1,0 +1,135 @@
+# Build and release workflow for blocksync-fast.
+# Builds and uploads GitHub releases (upon tag push) and assets every push.
+#
+# Testable locally with eg 'act -W .github/workflows/build-and-release.yml' using [1]
+# [1] https://github.com/nektos/act
+
+
+name: Build and Release
+
+on:
+  push
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: Update package lists
+      run: sudo apt-get update
+
+    - name: Install build essentials
+      run: |
+        sudo apt-get install -y --no-install-recommends \
+          build-essential \
+          autoconf \
+          automake \
+          libtool \
+          pkg-config
+
+    - name: Install optional xxhash dependencies
+      run: |
+        sudo apt-get install -y --no-install-recommends \
+          libxxhash-dev \
+          xxhash
+
+    - name: Install optional libgcrypt dependencies  
+      run: |
+        sudo apt-get install -y --no-install-recommends \
+          libgcrypt20-dev \
+          libgcrypt20
+
+    - name: Install DEB packaging dependencies
+      run: |
+        sudo apt-get install -y --no-install-recommends \
+          devscripts \
+          debhelper \
+          dh-autoreconf \
+          equivs \
+          dpkg-dev
+
+    - name: Create release directory
+      run: |
+        mkdir -p release
+ 
+    - name: Generate build files
+      run: |
+        autoreconf --install
+        ./configure
+    
+    - name: Build binary
+      run: |
+        make
+        cp src/blocksync-fast release/${{ steps.version.outputs.target_filename }}
+        chmod +x release/${{ steps.version.outputs.target_filename }}
+    
+    - name: Build deb package
+      run: |
+        # Install build dependencies
+        mk-build-deps
+        sudo apt install ./blocksync-fast-build-deps_*.deb
+        
+        # Build with fakeroot to avoid permission issues
+        sudo debuild -us -uc -b
+        
+        # Copy the deb package to release directory
+        cp ../blocksync-fast_*.deb release/ || true
+    
+    - name: Get version and architecture info
+      id: version
+      run: |
+        # Get git describe for version info
+        GIT_DESCRIBE=$(git describe --tags --long --dirty)
+        echo "git_describe=$GIT_DESCRIBE" >> $GITHUB_OUTPUT
+        
+        # Get commit hash
+        COMMIT_HASH=$(git rev-parse HEAD)
+        echo "commit_hash=$COMMIT_HASH" >> $GITHUB_OUTPUT
+        
+        # Get system architecture
+        ARCH=$(uname -m)
+        echo "arch=$ARCH" >> $GITHUB_OUTPUT
+        
+        # Get OS info
+        OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+        echo "os=$OS" >> $GITHUB_OUTPUT
+        
+        # Create target filename
+        TARGET_FILENAME="blocksync-fast-$OS-$ARCH"
+        echo "target_filename=$TARGET_FILENAME" >> $GITHUB_OUTPUT
+    
+    - name: Create release (on tag push)
+      uses: softprops/action-gh-release@v1
+      # Upload a release only if the push is a tag
+      if: github.event_name == 'push' && contains(github.ref, 'refs/tags/v*')
+      with:
+        tag_name: ${{ steps.version.outputs.git_describe }}
+        name: Release ${{ steps.version.outputs.git_describe }}
+        body: |
+          ## blocksync-fast ${{ steps.version.outputs.git_describe }}
+          
+          **Git Info:** ${{ steps.version.outputs.git_describe }}
+          **Commit:** ${{ steps.version.outputs.commit_hash }}
+        files: |
+          release/${{ steps.version.outputs.target_filename }}
+          release/blocksync-fast_*.deb
+        draft: false
+        prerelease: false
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
+
+    # Upload GitHub Action workflow *artifacts*. Note "artifacts" are a different concept to GitHub release assets. The former is available on each
+    # workflow run. The latter is associated with only a pushed tag.
+    - name: Upload build artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: blocksync-fast-${{ steps.version.outputs.git_describe }}-${{ steps.version.outputs.target_filename }}
+        path: |
+          release/${{ steps.version.outputs.target_filename }}
+          release/blocksync-fast_*.deb
+        retention-days: 30
+ 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Blocksync-fast
 ![blocksync-fast](https://raw.githubusercontent.com/nethappen/blocksync-fast/main/assets/images/blocksync-fast.png)
 
+[![Build Status](/actions/workflows/build-and-release.yml/badge.svg?event=push&branch=master)](/actions)
+
 Blocksync-fast is a program written in C that clones and synchronizes any block devices (entire disks, partitions) or files (disk images) using fast and efficient methods. It uses buffered reads and writes to combine adjacent blocks together reducing the number of I/O operations. At synchronization process program overwrites only changed blocks which reduces data transfer and maintains blocks deduplication in Copy-on-write file systems.
 
 The digest file can be used to store checksums of blocks from a previous sync to avoid read operations from the target disk. This optimization is especially desirable when synchronizing fast NVM drives with slower HDD drives or when transferring data over the network. The program can also creates delta file that stores only differing blocks which can be applied to the destination.

--- a/src/blocksync-fast.c
+++ b/src/blocksync-fast.c
@@ -32,7 +32,7 @@ void print_help(void)
 
 	fprintf(flag.prst, "\n");
 
-	fprintf(flag.prst, "Usage:\n",
+	fprintf(flag.prst, "%s: Usage:\n",
 			process_name);
 
 	fprintf(flag.prst, " %s [options]\n",
@@ -781,7 +781,7 @@ void init_params(void)
 		if (digest.path != NULL)
 			init_digest_file();
 		else
-			fprintf(flag.prst, "Warning: works without digest file.\n", process_name);
+			fprintf(flag.prst, "%s: Warning: works without digest file.\n", process_name);
 
 		if (IS_MODE(digest.open_mode, READ))
 			dst.open_mode ^= READ;
@@ -816,7 +816,7 @@ void init_params(void)
 		}
 
 		if (digest.path == NULL)
-			fprintf(flag.prst, "Warning: works without digest file.\n", process_name);
+			fprintf(flag.prst, "Warning: %s works without digest file.\n", process_name);
 
 		if (param.hash_algo != NULL)
 			check_algo_param();

--- a/src/globals.c
+++ b/src/globals.c
@@ -142,7 +142,7 @@ void map_buffer(struct dev *dev)
 
 			if (rbytes < 0)
 			{
-				fprintf(stderr, "%s: error while reading from stdin : %s\n", process_name, dev->path, strerror(errno));
+				fprintf(stderr, "%s: error while reading from stdin : %s (%s)\n", process_name, dev->path, strerror(errno));
 				cleanup(EXIT_FAILURE);
 			}
 


### PR DESCRIPTION
Hey, thought I'd share this GitHub Actions workflow I started putting together for this project while I was evaluating it.

The benefits of CI integration is every commit is built independently in an isolated environment. This workflow builds on every push and uploads a GitHub Action instance associated "asset" every push. And on tag, it uploads a release artifact on tag.

Before merging it needs a few quick tweaks
1. Upload plain binary, not just DEB package
2. Testing the on-tag behavior
3. Fixup the README badge

If you're interested I can polish it up.
